### PR TITLE
011: Enabled all other Sunrise-Sunset.org times

### DIFF
--- a/Source/Sunrise & Sunset/MockSunriseSunsetProvider.swift
+++ b/Source/Sunrise & Sunset/MockSunriseSunsetProvider.swift
@@ -3,19 +3,19 @@
 import PromiseKit
 import UIKit
 
-open class MockSunriseSunsetProvider: SunriseSunsetProvider {
+struct SimpleSunriseSunset: SunriseSunset {
+    var sunrise: Date
+    var sunset: Date
+}
 
-    struct MockSunriseSunset: SunriseSunset {
-        var sunrise: Date
-        var sunset: Date
-    }
+open class MockSunriseSunsetProvider: SunriseSunsetProvider {
 
     public func sunriseSunset() -> Promise<SunriseSunset> {
         return Promise<SunriseSunset> { (promise) in
             let startOfToday = Calendar.current.startOfDay(for: Date())
             let sunrise = startOfToday.addingTimeInterval(5.3 * 60.0 * 60.0)
             let sunset = startOfToday.addingTimeInterval(19.12 * 60.0 * 60.0)
-            promise.fulfill(MockSunriseSunset(sunrise: sunrise, sunset: sunset))
+            promise.fulfill(SimpleSunriseSunset(sunrise: sunrise, sunset: sunset))
         }
     }
     

--- a/Source/Sunrise & Sunset/MockSunriseSunsetProvider.swift
+++ b/Source/Sunrise & Sunset/MockSunriseSunsetProvider.swift
@@ -4,13 +4,18 @@ import PromiseKit
 import UIKit
 
 open class MockSunriseSunsetProvider: SunriseSunsetProvider {
-    
+
+    struct MockSunriseSunset: SunriseSunset {
+        var sunrise: Date
+        var sunset: Date
+    }
+
     public func sunriseSunset() -> Promise<SunriseSunset> {
         return Promise<SunriseSunset> { (promise) in
             let startOfToday = Calendar.current.startOfDay(for: Date())
             let sunrise = startOfToday.addingTimeInterval(5.3 * 60.0 * 60.0)
             let sunset = startOfToday.addingTimeInterval(19.12 * 60.0 * 60.0)
-            promise.fulfill(SunriseSunset(sunrise: sunrise, sunset: sunset))
+            promise.fulfill(MockSunriseSunset(sunrise: sunrise, sunset: sunset))
         }
     }
     

--- a/Source/Sunrise & Sunset/SunriseSunset.swift
+++ b/Source/Sunrise & Sunset/SunriseSunset.swift
@@ -2,18 +2,22 @@
 
 import Foundation
 
+public protocol SunriseSunset {
+
+    /// Sunrise. It's assumed that it's for the same day as the `sunset`; if
+    /// not, then that's a problem that this struct doesn't address.
+    var sunrise: Date { get }
+
+    /// Sunset. It's assumed that it's for the same day as the `sunrise`; if
+    /// not, then that's a problem that this struct doesn't address.
+    var sunset: Date { get }
+
+}
+
 /// Encapsulates `Date`s for a day's sunrise and sunset, and has numerous
 /// handy properties for calculating things like number of minutes of
 /// nighttime.
-public struct SunriseSunset: Codable {
-
-    /// Sunrise. It's assumed that it's for the same date as the `sunset`; if
-    /// not, then that's a problem that this struct doesn't address.
-    public let sunrise: Date
-
-    /// Sunset. It's assumed that it's for the same date as the `sunrise`; if
-    /// not, then that's a problem that this struct doesn't address.
-    public let sunset: Date
+public extension SunriseSunset {
 
     // MARK: - Computed Properties
 
@@ -45,13 +49,6 @@ public struct SunriseSunset: Codable {
     /// An array of `Date`s of the nighttime hours.
     public var nighttimeHourTimes: [Date] {
         return (0..<12).map { sunset.addingTimeInterval(nighttimeHourDuration * 60 * Double($0)) }
-    }
-    
-    // MARK: - Initializers
-    
-    public init(sunrise: Date, sunset: Date) {
-        self.sunrise = sunrise
-        self.sunset = sunset
     }
 
 }

--- a/Tests/Sunrise & Sunset/SunriseSunsetTests.swift
+++ b/Tests/Sunrise & Sunset/SunriseSunsetTests.swift
@@ -13,26 +13,26 @@ class SunriseSunsetTests: XCTestCase {
     }
 
     func testDaylightMinutesOk() {
-        let sunriseSunset = SunriseSunset(sunrise: date(7, 13),
-                                          sunset: date(18, 33))
+        let sunriseSunset = SimpleSunriseSunset(sunrise: date(7, 13),
+                                                sunset: date(18, 33))
         XCTAssertEqual(sunriseSunset.daylightMinutes, 680)
     }
 
     func testDaylightHourDurationOk() {
-        let sunriseSunset = SunriseSunset(sunrise: date(7, 13),
-                                          sunset: date(18, 33))
+        let sunriseSunset = SimpleSunriseSunset(sunrise: date(7, 13),
+                                                sunset: date(18, 33))
         XCTAssertEqual(sunriseSunset.daylightHourDuration, 680 / 12)
     }
 
     func testNighttimeMinutesOk() {
-        let sunriseSunset = SunriseSunset(sunrise: date(7, 13),
-                                          sunset: date(18, 33))
+        let sunriseSunset = SimpleSunriseSunset(sunrise: date(7, 13),
+                                                sunset: date(18, 33))
         XCTAssertEqual(sunriseSunset.nighttimeMinutes, 760)
     }
 
     func testNighttimeHourDurationOk() {
-        let sunriseSunset = SunriseSunset(sunrise: date(7, 13),
-                                          sunset: date(18, 33))
+        let sunriseSunset = SimpleSunriseSunset(sunrise: date(7, 13),
+                                                sunset: date(18, 33))
         XCTAssertEqual(sunriseSunset.nighttimeHourDuration, (760) / 12)
     }
 


### PR DESCRIPTION
Issue #11: Add astronomical data to SunriseSunset

- `SunriseSunset`  is now a protocol, and the unit tests have a mock implementation of it.
- Refactored `SunriseSunsetDotOrgProvider.ResponseData.Results` to implement `SunriseSunset`, and enabled all of its other fields (except `dayLength`). This involved adding a custom `DateDecodingStrategy` to the `JSONDecoder`.